### PR TITLE
Add commit hash to URL identifier for release 1.0.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ identifiers:
     value: "https://github.com/Imageomics/Butterfly-mimicry/releases/tag/v1.0.0"
   - description: "The GitHub URL of the commit tagged with 1.0.0."
     type: url
-    value: "https://github.com/Imageomics/Butterfly-mimicry/tree/<commit>"
+    value: "https://github.com/Imageomics/Butterfly-mimicry/tree/482c3a8bd23846cc2777f0f179f3ef25a3a5d867"
 keywords:
   - "imageomics"
   - "butterflies"


### PR DESCRIPTION
Adds the commit hash to the URL in the identifier for release 1.0.0 in the `CITATION.cff` file.